### PR TITLE
Revert propkill.nut's name on MapEnd

### DIFF
--- a/addons/sourcemod/scripting/propkill.sp
+++ b/addons/sourcemod/scripting/propkill.sp
@@ -176,6 +176,11 @@ public void OnMapEnd()
 		cvar = FindConVar("sv_duckbunnyhopping");
 		if(cvar)
 			cvar.BoolValue = false;
+
+		if(FileExists("scripts/vscripts/_temppropkill.nut", false))
+		{
+			RenameFile("scripts/vscripts/propkill.nut", "scripts/vscripts/_temppropkill.nut");
+		}
 	}
 }
 


### PR DESCRIPTION
- I'm not sure to remove line 82 even though it doesn't need.

This should solve #1.